### PR TITLE
Handle and log signals. Additionally log willSleep notification

### DIFF
--- a/Sources/LockStateObserver/Extensions/Int32.swift
+++ b/Sources/LockStateObserver/Extensions/Int32.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension Int32 {
+    var signalDescription: String {
+        switch self {
+        case SIGKILL: "SIGKILL"
+        case SIGTERM: "SIGTERM"
+        case SIGINT: "SIGINT"
+        default: "\(self)"
+        }
+    }
+}

--- a/Sources/LockStateObserver/Extensions/String.swift
+++ b/Sources/LockStateObserver/Extensions/String.swift
@@ -7,4 +7,8 @@ extension String {
         dateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
         return "\(dateFormatter.string(from: date)): \(self)\n"
     }
+
+    var prefixSpaceIfNotEmpty: String {
+        isEmpty ? "" : " \(self)"
+    }
 }

--- a/Sources/LockStateObserver/LockStateObserver.swift
+++ b/Sources/LockStateObserver/LockStateObserver.swift
@@ -4,12 +4,24 @@ import Foundation
 @main
 public struct LockStateObserver {
     public static func main() {
+        Logger.write("process started")
         configureNotificationObserver()
-        Logger.write("started")
+        configureSignalHandlers()
         RunLoop.main.run()
     }
 
     // MARK: - Private
+
+    private static func configureSignalHandlers() {
+        [SIGINT, SIGTERM, SIGKILL].forEach {
+            signal($0) {
+                Logger.logSignal($0)
+                if [SIGTERM, SIGINT].contains($0) {
+                    exit(0)
+                }
+            }
+        }
+    }
 
     private static func configureNotificationObserver() {
         let dnc = DistributedNotificationCenter.default()
@@ -26,6 +38,7 @@ public struct LockStateObserver {
 
         let workspaceNotifications: [NSNotification.Name] = [
             NSWorkspace.willPowerOffNotification,
+            NSWorkspace.willSleepNotification,
             NSWorkspace.screensDidWakeNotification,
             NSWorkspace.screensDidSleepNotification
         ]

--- a/Sources/LockStateObserver/Logger.swift
+++ b/Sources/LockStateObserver/Logger.swift
@@ -26,6 +26,10 @@ public struct Logger {
         write(notification.name.rawValue)
     }
 
+    static func logSignal(_ signal: Int32) {
+        write("Signal \(signal.signalDescription) received")
+    }
+
     // MARK: - Private
 
     private static func formatData(logMessage: String, date: Date?) -> Data? {


### PR DESCRIPTION
Add signal handlers for SIGINT, SIGTERM and SIGKILL. Idea behind was to provide an alternative way to detect a shutdown event, given the willPowerOffNotification from NSWorkspace doesn't seem to work. willSleepNotification works though, and was also added on this PR. The corner case of this solution is the program being killed for any reason will count a shutdown. IMO it's a very minor problem.